### PR TITLE
Add propagation model includes

### DIFF
--- a/examples/wireless/wifi-phy-interference.cc
+++ b/examples/wireless/wifi-phy-interference.cc
@@ -75,10 +75,12 @@
 #include "ns3/log.h"
 #include "ns3/mobility-helper.h"
 #include "ns3/mobility-model.h"
+#include "ns3/multi-model-spectrum-channel.h"
+#include "ns3/propagation-delay-model.h"
+#include "ns3/propagation-loss-model.h"
+#include "ns3/spectrum-wifi-helper.h"
 #include "ns3/ssid.h"
 #include "ns3/string.h"
-#include "ns3/multi-model-spectrum-channel.h"
-#include "ns3/spectrum-wifi-helper.h"
 
 using namespace ns3;
 
@@ -196,7 +198,8 @@ main(int argc, char* argv[])
 
     Ptr<MultiModelSpectrumChannel> spectrumChannel = CreateObject<MultiModelSpectrumChannel>();
     spectrumChannel->SetPropagationDelayModel(CreateObject<ConstantSpeedPropagationDelayModel>());
-    Ptr<LogDistancePropagationLossModel> lossModel = CreateObject<LogDistancePropagationLossModel>();
+    Ptr<LogDistancePropagationLossModel> lossModel =
+        CreateObject<LogDistancePropagationLossModel>();
     spectrumChannel->AddPropagationLossModel(lossModel);
     wifiPhy.SetChannel(spectrumChannel);
     wifiPhy.SetErrorRateModel("ns3::YansErrorRateModel");


### PR DESCRIPTION
## Summary
- include propagation delay/loss headers in wifi-phy-interference example
- run clang-format on the file

## Testing
- `./ns3 configure --enable-examples --enable-tests`
- `./ns3 build` *(failed: interrupted by user)*

------
https://chatgpt.com/codex/tasks/task_e_68484d44a9f48322b36cefcc5bdeac21