### PR TITLE
Fix tolerance check in spectrum-wifi-phy

### DIFF
--- a/src/wifi/model/spectrum-wifi-phy.cc
+++ b/src/wifi/model/spectrum-wifi-phy.cc
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <numeric>
+#include <cmath>
 
 #undef NS_LOG_APPEND_CONTEXT
 #define NS_LOG_APPEND_CONTEXT WIFI_PHY_NS_LOG_APPEND_CONTEXT(Ptr(this, false))
@@ -784,7 +785,10 @@ SpectrumWifiPhy::GetBandForInterface(Ptr<WifiSpectrumPhyInterface> spectrumPhyIn
         auto freqRange = spectrumPhyInterface->GetFrequencyRange();
         NS_ASSERT(frequencies.first >= MHzToHz(freqRange.minFrequency));
         NS_ASSERT(frequencies.second <= MHzToHz(freqRange.maxFrequency));
-        NS_ASSERT((frequencies.second - frequencies.first) == MHzToHz(bandWidth));
+        const Hz_u expected = MHzToHz(bandWidth);
+        const Hz_u measured = frequencies.second - frequencies.first;
+        const Hz_u tolerance = GetSubcarrierSpacing() / 2.0;
+        NS_ASSERT(std::abs(measured - expected) <= tolerance);
         if (startIndex >= totalNumBands / 2)
         {
             // step past DC


### PR DESCRIPTION
## Summary
- add missing `<cmath>` include
- use tolerance when comparing measured and expected band width

## Testing
- `./ns3 configure --enable-examples --enable-tests` *(fails: ninja build interrupted)*
- `./test.py -c core` *(fails: ninja build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68496ebb17e483228b6385c5963a3be7