### PR TITLE
Fix wifi band tolerance check

### DIFF
--- a/src/wifi/model/spectrum-wifi-phy.cc
+++ b/src/wifi/model/spectrum-wifi-phy.cc
@@ -29,6 +29,7 @@
 #include "ns3/spectrum-channel.h"
 
 #include <algorithm>
+#include <cmath>
 #include <numeric>
 
 #undef NS_LOG_APPEND_CONTEXT
@@ -784,7 +785,10 @@ SpectrumWifiPhy::GetBandForInterface(Ptr<WifiSpectrumPhyInterface> spectrumPhyIn
         auto freqRange = spectrumPhyInterface->GetFrequencyRange();
         NS_ASSERT(frequencies.first >= MHzToHz(freqRange.minFrequency));
         NS_ASSERT(frequencies.second <= MHzToHz(freqRange.maxFrequency));
-        NS_ASSERT((frequencies.second - frequencies.first) == MHzToHz(bandWidth));
+        const Hz_u expected = MHzToHz(bandWidth);
+        const Hz_u measured = frequencies.second - frequencies.first;
+        const Hz_u tolerance = GetSubcarrierSpacing() / 2.0;
+        NS_ASSERT(std::abs(measured - expected) <= tolerance);
         if (startIndex >= totalNumBands / 2)
         {
             // step past DC


### PR DESCRIPTION
## Summary
- include `<cmath>` in `spectrum-wifi-phy.cc`
- replace equality assertion with tolerance check when computing band widths

## Testing
- `./ns3 build wifi`
- ❌ `./test.py` *(failed: ns3 died. Not running tests)*

------
https://chatgpt.com/codex/tasks/task_e_684935e2ab0c832296bb95ad2d3174e1