### PR TITLE
Fix wifi-ble-interference channel settings

### DIFF
--- a/examples/wireless/wifi-ble-interference.cc
+++ b/examples/wireless/wifi-ble-interference.cc
@@ -231,7 +231,7 @@ main(int argc, char* argv[])
     spectrumChannel->AddPropagationLossModel(lossModel);
     wifiPhy.SetChannel(spectrumChannel);
     wifiPhy.SetErrorRateModel("ns3::YansErrorRateModel");
-    wifiPhy.Set("ChannelSettings", StringValue("{6, 0, BAND_2_4GHZ, 0}"));
+    wifiPhy.Set("ChannelSettings", StringValue("{6, 20, BAND_2_4GHZ, 0}"));
 
     // Add a mac and disable rate control
     WifiMacHelper wifiMac;


### PR DESCRIPTION
## Summary
- adjust ChannelSettings in wifi-ble-interference example

## Testing
- `./ns3 configure --enable-examples`
- `./ns3 build wifi-ble-interference` *(fails: KeyboardInterrupt)*
- `./ns3 run wifi-ble-interference` *(fails: program not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849eae9e070832287a4cefaf7bc2a55