### PR TITLE
Add missing Wi-Fi example includes

### DIFF
--- a/examples/wireless/new-wifi-multiple-devices.cc
+++ b/examples/wireless/new-wifi-multiple-devices.cc
@@ -12,6 +12,8 @@
 #include "ns3/mobility-helper.h"
 #include "ns3/on-off-helper.h"
 #include "ns3/packet-sink-helper.h"
+#include "ns3/ipv4-flow-classifier.h"
+#include "ns3/string.h"
 #include "ns3/ssid.h"
 #include "ns3/uinteger.h"
 #include "ns3/yans-wifi-channel.h"


### PR DESCRIPTION
## Summary
- include `string.h` for `StringValue`
- include `ipv4-flow-classifier.h` for `Ipv4FlowClassifier`

## Testing
- `python3 utils/check-style-clang-format.py examples/wireless/new-wifi-multiple-devices.cc` *(fails: Could not find supported clang-format)*
- `./ns3 configure --enable-examples`
- `./ns3 build examples/wireless/new-wifi-multiple-devices.cc`

------
https://chatgpt.com/codex/tasks/task_e_684aa47113c8832294d2913e5003cc7a