### PR TITLE
Add missing include for flow classifier

### DIFF
--- a/scratch/wifi7-industrial-mlo.cc
+++ b/scratch/wifi7-industrial-mlo.cc
@@ -6,6 +6,7 @@
 #include "ns3/internet-module.h"
 #include "ns3/udp-client-server-helper.h"
 #include "ns3/flow-monitor-helper.h"
+#include "ns3/ipv4-flow-classifier.h"
 
 using namespace ns3;
 


### PR DESCRIPTION
## Summary
- include ns3/ipv4-flow-classifier.h in wifi7-industrial-mlo example

## Testing
- `./ns3 configure -G Ninja --enable-examples --disable-python -- -DNS3_ENABLED_MODULES='core;network;mobility;spectrum;wifi;internet;applications;flow-monitor'`
- `ninja -C cmake-cache scratch_wifi7-industrial-mlo` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686cf529d0d4832295eb998a9953a1fc