### PR TITLE
Add GPL boilerplate to wifi7-industrial example

### DIFF
--- a/scratch/wifi7-industrial-mlo.cc
+++ b/scratch/wifi7-industrial-mlo.cc
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
 #include "ns3/core-module.h"
 #include "ns3/network-module.h"
 #include "ns3/mobility-module.h"


### PR DESCRIPTION
## Summary
- add GPLv2 license header to `scratch/wifi7-industrial-mlo.cc`

## Testing
- `./test.py -h`

------
https://chatgpt.com/codex/tasks/task_e_686cf52a9578832293c647c9194faf37