### PR TITLE
Add runtime options for Wi-Fi 7 scratch program

### DIFF
--- a/scratch/wifi7-industrial-mlo.cc
+++ b/scratch/wifi7-industrial-mlo.cc
@@ -16,6 +16,11 @@ int main(int argc, char* argv[])
     uint32_t nSta = 10;
     Time simTime = Seconds(10);
 
+    CommandLine cmd(__FILE__);
+    cmd.AddValue("nSta", "Number of station nodes", nSta);
+    cmd.AddValue("simTime", "Simulation duration", simTime);
+    cmd.Parse(argc, argv);
+
     NodeContainer apNode;
     apNode.Create(1);
     NodeContainer staNodes;


### PR DESCRIPTION
## Summary
- allow choosing number of STAs and simulation time from the command line

## Testing
- `./ns3 configure --enable-examples --enable-tests`
- `ninja -C cmake-cache scratch_wifi7-industrial-mlo` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686cf52bb684832281488f6c6b44a517