### PR TITLE
Add usage notes for wifi7 example

### DIFF
--- a/scratch/wifi7-industrial-mlo.cc
+++ b/scratch/wifi7-industrial-mlo.cc
@@ -1,5 +1,9 @@
 /*
  * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Example usage:
+ *   ./ns3 run "scratch/wifi7-industrial-mlo --nSta=20 --simTime=15s"
+ *   ./ns3 run "scratch/wifi7-industrial-mlo --nSta=50 --simTime=30s"
  */
 
 #include "ns3/core-module.h"


### PR DESCRIPTION
## Summary
- document how to run `wifi7-industrial-mlo` with the new options

## Testing
- `./utils/check-style-clang-format.py scratch/wifi7-industrial-mlo.cc` *(fails: clang-format 20 not supported)*
- `./utils/check-style-clang-format.py --no-formatting scratch/wifi7-industrial-mlo.cc`

------
https://chatgpt.com/codex/tasks/task_e_686d1586f82083229d9a3179de92fdf7