### PR TITLE
Handle flows with no received packets

### DIFF
--- a/scratch/wifi7-industrial-mlo.cc
+++ b/scratch/wifi7-industrial-mlo.cc
@@ -122,13 +122,21 @@ int main(int argc, char* argv[])
         Ipv4FlowClassifier::FiveTuple t = classifier->FindFlow(s.first);
         if (t.sourceAddress == apIf.GetAddress(0))
         {
-            double throughput = s.second.rxBytes * 8.0 /
-                                  (s.second.timeLastRxPacket.GetSeconds() -
-                                   s.second.timeFirstTxPacket.GetSeconds()) / 1e6;
-            double delay = s.second.delaySum.GetSeconds() / s.second.rxPackets;
-            std::cout << "Flow to " << t.destinationAddress
-                      << " Throughput: " << throughput << " Mbit/s"
-                      << " Avg Delay: " << delay * 1000 << " ms" << std::endl;
+            if (s.second.rxPackets > 0 &&
+                s.second.timeLastRxPacket > s.second.timeFirstTxPacket)
+            {
+                double throughput = s.second.rxBytes * 8.0 /
+                                      (s.second.timeLastRxPacket.GetSeconds() -
+                                       s.second.timeFirstTxPacket.GetSeconds()) / 1e6;
+                double delay = s.second.delaySum.GetSeconds() / s.second.rxPackets;
+                std::cout << "Flow to " << t.destinationAddress
+                          << " Throughput: " << throughput << " Mbit/s"
+                          << " Avg Delay: " << delay * 1000 << " ms" << std::endl;
+            }
+            else
+            {
+                std::cout << "Flow to " << t.destinationAddress << " No packets received" << std::endl;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid displaying -0 or NaN statistics in wifi7-industrial-mlo example
- show a helpful message if no packets are received

## Testing
- `./ns3 configure --enable-examples --enable-tests`
- `./ns3 build` *(fails: interrupted by user)*

------
https://chatgpt.com/codex/tasks/task_e_686e6d0f10b083228c795871b02a2869