### PR TITLE
Adjust UDP client start time

### DIFF
--- a/scratch/wifi7-industrial-mlo.cc
+++ b/scratch/wifi7-industrial-mlo.cc
@@ -104,7 +104,8 @@ int main(int argc, char* argv[])
         client.SetAttribute("Interval", TimeValue(MicroSeconds(100)));
         client.SetAttribute("PacketSize", UintegerValue(1200));
         ApplicationContainer clientApp = client.Install(apNode.Get(0));
-        clientApp.Start(Seconds(1.0));
+        // Start traffic after STAs have had time to associate
+        clientApp.Start(Seconds(2.0));
         clientApp.Stop(simTime);
     }
 

--- a/src/wifi/examples/wifi-co-trace-example.cc
+++ b/src/wifi/examples/wifi-co-trace-example.cc
@@ -175,17 +175,18 @@ main(int argc, char* argv[])
     }
 
     sinkApplications.Start(Seconds(0.0));
-    sinkApplications.Stop(Seconds(1.0) + duration + MilliSeconds(20));
-    sourceApplications.Start(Seconds(1.0));
-    sourceApplications.Stop(Seconds(1.0) + duration);
+    // Allow association to complete before starting traffic
+    sinkApplications.Stop(Seconds(2.0) + duration + MilliSeconds(20));
+    sourceApplications.Start(Seconds(2.0));
+    sourceApplications.Stop(Seconds(2.0) + duration);
 
     // Use the NeighborCacheHelper to avoid ARP messages (ARP replies, since they are unicast,
     // count in the statistics.  The cache operation must be scheduled after WifiNetDevices are
     // started, until issue #851 is fixed.  The indirection through a normal function is
     // necessary because NeighborCacheHelper::PopulateNeighborCache() is overloaded
-    Simulator::Schedule(Seconds(0.99), &PopulateNeighborCache);
+    Simulator::Schedule(Seconds(1.99), &PopulateNeighborCache);
 
-    WifiCoTraceHelper wifiCoTraceHelper(Seconds(1), Seconds(1) + duration);
+    WifiCoTraceHelper wifiCoTraceHelper(Seconds(2), Seconds(2) + duration);
     wifiCoTraceHelper.Enable(allDevices);
 
     Simulator::Stop(duration + Seconds(2));


### PR DESCRIPTION
## Summary
- start UDP clients later in wifi7-industrial-mlo example
- start traffic later in wifi-co-trace example

## Testing
- `./ns3 configure --enable-examples --enable-tests`
- `./ns3 build` *(fails: interrupted)*
- `./test.py -c core` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686e6f45052083228207923d9351a69e