### PR TITLE
Fix wifi7 example remote station manager

### DIFF
--- a/scratch/wifi7-industrial-mlo.cc
+++ b/scratch/wifi7-industrial-mlo.cc
@@ -4,7 +4,12 @@
  * Example usage:
  *   ./ns3 run "scratch/wifi7-industrial-mlo --nSta=20 --simTime=15s"
  *   ./ns3 run "scratch/wifi7-industrial-mlo --nSta=50 --simTime=30s"
- */
+ *
+ * Note: Multi-Link Operation support is still evolving in ns-3.  The
+ * Wi-Fi documentation warns that some features (e.g., EMLSR) remain
+ * experimental and may lead to crashes.  This example configures two
+ * links but avoids enabling EMLSR explicitly.
+*/
 
 #include "ns3/core-module.h"
 #include "ns3/network-module.h"
@@ -43,9 +48,12 @@ int main(int argc, char* argv[])
 
     WifiHelper wifi;
     wifi.SetStandard(WIFI_STANDARD_80211be);
-    // Use MinstrelHtWifiManager for rate adaptation and disable the
-    // experimental EMLSR option to avoid crashes.
-    wifi.SetRemoteStationManager("ns3::MinstrelHtWifiManager");
+    // Use MinstrelHtWifiManager for rate adaptation on each link.  The
+    // Wi-Fi documentation notes that EMLSR and some MLO features are
+    // still experimental and can cause crashes; this example avoids
+    // enabling them explicitly.
+    wifi.SetRemoteStationManager(static_cast<uint8_t>(0), "ns3::MinstrelHtWifiManager");
+    wifi.SetRemoteStationManager(static_cast<uint8_t>(1), "ns3::MinstrelHtWifiManager");
 
     SpectrumWifiPhyHelper phy(2);
     phy.SetPcapDataLinkType(WifiPhyHelper::DLT_IEEE802_11_RADIO);


### PR DESCRIPTION
## Summary
- clarify docs about MLO stability in `wifi7-industrial-mlo.cc`
- set the remote station manager on both links explicitly and cast link IDs to `uint8_t` to match API expectations

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686e821edc948322ab12b568047293f1