### PR TITLE
Add SPDX header to wifi calibration example

### DIFF
--- a/scratch/subdir/wifi-eht-calibration.cc
+++ b/scratch/subdir/wifi-eht-calibration.cc
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
 #include "ns3/command-line.h"
 #include "ns3/flow-monitor-helper.h"
 #include "ns3/internet-stack-helper.h"


### PR DESCRIPTION
## Summary
- add SPDX license header to `wifi-eht-calibration.cc`

## Testing
- `./ns3 configure --enable-examples --enable-tests` *(fails: multiple scratch files with `main()`)*
- `./test.py --constrain=core -f QUICK --no-build` *(fails: requires configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6878dd8ef90083229c066d8878c5ae81