### PR TITLE
Add missing std headers

### DIFF
--- a/scratch/subdir/wifi-eht-calibration.cc
+++ b/scratch/subdir/wifi-eht-calibration.cc
@@ -11,6 +11,11 @@
 #include "ns3/yans-wifi-helper.h"
 #include "ns3/gnuplot.h"
 #include "ns3/yans-error-rate-model.h"
+#include <vector>
+#include <sstream>
+#include <fstream>
+#include <cmath>
+#include <string>
 
 using namespace ns3;
 


### PR DESCRIPTION
## Summary
- add standard includes to wifi-eht-calibration

## Testing
- `c++ -fsyntax-only scratch/subdir/wifi-eht-calibration.cc` (fails: 'StringValue' not declared)

------
https://chatgpt.com/codex/tasks/task_e_6878dd909d94832299b2075281489e32