### PR TITLE
Fix unused variable warning

### DIFF
--- a/scratch/subdir/wifi-eht-calibration.cc
+++ b/scratch/subdir/wifi-eht-calibration.cc
@@ -101,7 +101,6 @@ RunExperiment(double distance, const std::string& mcs, Time simulationTime)
     Ipv4AddressHelper address;
     address.SetBase("10.1.0.0", "255.255.255.0");
     Ipv4InterfaceContainer staIf = address.Assign(staDevice);
-    Ipv4InterfaceContainer apIf = address.Assign(apDevice);
 
     uint16_t port = 9;
     UdpServerHelper server(port);


### PR DESCRIPTION
## Summary
- remove the unused variable `apIf` in wifi-eht-calibration example

## Testing
- `cmake -S . -B build -DNS3_ENABLE_EXAMPLES=ON -DNS3_ENABLE_TESTS=OFF` *(fails: multiple main functions)*
- `cmake --build build -j $(nproc) --target scratch_subdir_wifi-eht-calibration` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6878dd93edc0832298e03273771053df