### PR TITLE
Use configured guard interval fallback

### DIFF
--- a/src/wifi/model/wifi-remote-station-manager.cc
+++ b/src/wifi/model/wifi-remote-station-manager.cc
@@ -1707,8 +1707,8 @@ WifiRemoteStationManager::AddStationHeCapabilities(Mac48Address from,
     }
     else
     {
-        // todo: Using 3200ns, default value for HeConfiguration::GuardInterval
-        state->m_guardInterval = NanoSeconds(3200);
+        // fall back to the device configuration guard interval
+        state->m_guardInterval = GetGuardInterval();
     }
     for (const auto& mcs : m_wifiPhy->GetMcsList(WIFI_MOD_CLASS_HE))
     {


### PR DESCRIPTION
## Summary
- respect HeConfiguration guard interval when peer does not advertise 0.8 us GI

## Testing
- `./ns3 configure` *(passes)*
- `./ns3 build` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6887fa3f73b083229fbed3e50d5f438b