### PR TITLE
Enhance wifi-eht-minimal example

### DIFF
--- a/examples/wireless/wifi-eht-minimal.cc
+++ b/examples/wireless/wifi-eht-minimal.cc
@@ -5,14 +5,16 @@
 #include "ns3/ipv4-address-helper.h"
 #include "ns3/ipv4-flow-classifier.h"
 #include "ns3/ipv4-global-routing-helper.h"
-#include "ns3/string.h"
 #include "ns3/mobility-helper.h"
 #include "ns3/ssid.h"
+#include "ns3/string.h"
 #include "ns3/udp-client-server-helper.h"
 #include "ns3/udp-server.h"
 #include "ns3/uinteger.h"
 #include "ns3/yans-wifi-channel.h"
 #include "ns3/yans-wifi-helper.h"
+
+#include <array>
 
 using namespace ns3;
 
@@ -20,15 +22,19 @@ int
 main(int argc, char* argv[])
 {
     Time simulationTime{"30s"};
-    std::string mcs{"EhtMcs1"};
+    std::string mcs{"EhtMcs13"};
+    uint16_t channelWidth{320};
+    uint16_t guardInterval{800};
 
     CommandLine cmd(__FILE__);
     cmd.AddValue("simulationTime", "Simulation time", simulationTime);
     cmd.AddValue("mcs", "EHT MCS", mcs);
+    cmd.AddValue("channelWidth", "Channel width in MHz", channelWidth);
+    cmd.AddValue("guardInterval", "Guard interval in nanoseconds", guardInterval);
     cmd.Parse(argc, argv);
 
-    NodeContainer staNode;
-    staNode.Create(1);
+    NodeContainer staNodes;
+    staNodes.Create(4);
     NodeContainer apNode;
     apNode.Create(1);
 
@@ -43,46 +49,60 @@ main(int argc, char* argv[])
                                  StringValue(mcs),
                                  "ControlMode",
                                  StringValue(mcs));
+    Config::Set("/NodeList/*/DeviceList/*/$ns3::WifiNetDevice/Phy/ChannelSettings",
+                StringValue("{0, " + std::to_string(channelWidth) + ", BAND_6GHZ, 0}"));
+    Config::Set("/NodeList/*/DeviceList/*/$ns3::WifiNetDevice/HeConfiguration/GuardInterval",
+                TimeValue(NanoSeconds(guardInterval)));
     WifiMacHelper mac;
 
     Ssid ssid = Ssid("ns3-80211be");
     mac.SetType("ns3::StaWifiMac", "Ssid", SsidValue(ssid));
-    NetDeviceContainer staDevice = wifi.Install(phy, mac, staNode);
+    NetDeviceContainer staDevices = wifi.Install(phy, mac, staNodes);
 
     mac.SetType("ns3::ApWifiMac", "Ssid", SsidValue(ssid));
     NetDeviceContainer apDevice = wifi.Install(phy, mac, apNode);
 
     MobilityHelper mobility;
     Ptr<ListPositionAllocator> positionAlloc = CreateObject<ListPositionAllocator>();
-    positionAlloc->Add(Vector(0.0, 0.0, 0.0));
-    positionAlloc->Add(Vector(5.0, 0.0, 0.0));
+    positionAlloc->Add(Vector(0.0, 0.0, 0.0)); // AP
+    positionAlloc->Add(Vector(1.0, 0.0, 0.0));
+    positionAlloc->Add(Vector(0.0, 1.0, 0.0));
+    positionAlloc->Add(Vector(-1.0, 0.0, 0.0));
+    positionAlloc->Add(Vector(0.0, -1.0, 0.0));
     mobility.SetPositionAllocator(positionAlloc);
     mobility.SetMobilityModel("ns3::ConstantPositionMobilityModel");
     mobility.Install(apNode);
-    mobility.Install(staNode);
+    mobility.Install(staNodes);
 
     InternetStackHelper stack;
     stack.Install(apNode);
-    stack.Install(staNode);
+    stack.Install(staNodes);
 
     Ipv4AddressHelper address;
     address.SetBase("192.168.1.0", "255.255.255.0");
-    Ipv4InterfaceContainer staIf = address.Assign(staDevice);
-    Ipv4InterfaceContainer apIf = address.Assign(apDevice);
+    Ipv4InterfaceContainer staIf = address.Assign(staDevices);
+    address.Assign(apDevice);
 
     uint16_t port = 9;
-    UdpServerHelper server(port);
-    ApplicationContainer serverApp = server.Install(staNode.Get(0));
-    serverApp.Start(Seconds(0));
-    serverApp.Stop(simulationTime + Seconds(1));
+    std::array<uint8_t, 4> tosValues{0xc0, 0xb8, 0x70, 0x28}; // VO, VI, BE, BK
+    ApplicationContainer serverApps;
+    ApplicationContainer clientApps;
+    for (uint32_t i = 0; i < staNodes.GetN(); ++i)
+    {
+        UdpServerHelper server(port + i);
+        serverApps.Add(server.Install(staNodes.Get(i)));
 
-    UdpClientHelper client(staIf.GetAddress(0), port);
-    client.SetAttribute("MaxPackets", UintegerValue(4294967295U));
-    client.SetAttribute("Interval", TimeValue(Time("0.0001")));
-    client.SetAttribute("PacketSize", UintegerValue(1472));
-    ApplicationContainer clientApp = client.Install(apNode.Get(0));
-    clientApp.Start(Seconds(1));
-    clientApp.Stop(simulationTime + Seconds(1));
+        UdpClientHelper client(staIf.GetAddress(i), port + i);
+        client.SetAttribute("MaxPackets", UintegerValue(4294967295U));
+        client.SetAttribute("Interval", TimeValue(Time("0.0001")));
+        client.SetAttribute("PacketSize", UintegerValue(1472));
+        client.SetAttribute("Tos", UintegerValue(tosValues[i]));
+        clientApps.Add(client.Install(apNode.Get(0)));
+    }
+    serverApps.Start(Seconds(0));
+    serverApps.Stop(simulationTime + Seconds(1));
+    clientApps.Start(Seconds(1));
+    clientApps.Stop(simulationTime + Seconds(1));
 
     Ipv4GlobalRoutingHelper::PopulateRoutingTables();
 
@@ -95,21 +115,29 @@ main(int argc, char* argv[])
     monitor->CheckForLostPackets();
     Ptr<Ipv4FlowClassifier> classifier = DynamicCast<Ipv4FlowClassifier>(flowmon.GetClassifier());
     auto stats = monitor->GetFlowStats();
+    std::array<std::string, 4> acNames{"VO", "VI", "BE", "BK"};
     for (const auto& s : stats)
     {
         auto t = classifier->FindFlow(s.first);
-        if (t.destinationAddress == staIf.GetAddress(0))
+        for (uint32_t i = 0; i < staNodes.GetN(); ++i)
         {
-
-            double throughput = s.second.rxBytes * 8.0 / (simulationTime.GetSeconds()) / 1e6;
-            double meanDelay =
-                s.second.rxPackets ? s.second.delaySum.GetSeconds() / s.second.rxPackets : 0.0;
-            std::cout << "Throughput: " << throughput << " Mbps" << std::endl;
-            std::cout << "Mean delay: " << meanDelay << " s" << std::endl;
+            if (t.destinationAddress == staIf.GetAddress(i))
+            {
+                double throughput = s.second.rxBytes * 8.0 / (simulationTime.GetSeconds()) / 1e6;
+                double meanDelay =
+                    s.second.rxPackets ? s.second.delaySum.GetSeconds() / s.second.rxPackets : 0.0;
+                double ber = s.second.txBytes
+                                 ? static_cast<double>(s.second.txBytes - s.second.rxBytes) * 8 /
+                                       (s.second.txBytes * 8)
+                                 : 0.0;
+                std::cout << acNames[i] << " throughput: " << throughput << " Mbps" << std::endl;
+                std::cout << acNames[i] << " mean delay: " << meanDelay << " s" << std::endl;
+                std::cout << acNames[i] << " BER: " << ber << std::endl;
+                break;
+            }
         }
     }
 
     Simulator::Destroy();
     return 0;
-  
 }


### PR DESCRIPTION
## Summary
- create 4 stations around a single AP using different TOS values
- add configurable MCS, channel width and guard interval
- allow 6 GHz 320 MHz with 4096-QAM
- report throughput, latency and BER per station

## Testing
- `./ns3 configure --enable-examples --enable-tests`
- `./ns3 build examples/wireless/wifi-eht-minimal` *(failed: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6888931997a083228e532f780128d33c