### PR TITLE
Add FlowMonitor to wifi-lte traffic example

### DIFF
--- a/scratch/wifi-lte-traffic.cc
+++ b/scratch/wifi-lte-traffic.cc
@@ -7,6 +7,7 @@
 #include "ns3/udp-client-server-helper.h"
 #include "ns3/packet-sink-helper.h"
 #include "ns3/socket.h"
+#include "ns3/flow-monitor-module.h"
 
 using namespace ns3;
 
@@ -146,8 +147,22 @@ main(int argc, char *argv[])
   voiceApp2->SetStartTime(Seconds(1.0));
   voiceApp2->SetStopTime(Seconds(10.0));
 
+  FlowMonitorHelper flowmonHelper;
+  Ptr<FlowMonitor> monitor = flowmonHelper.InstallAll();
+
   Simulator::Stop(Seconds(10.0));
   Simulator::Run();
+  monitor->CheckForLostPackets();
+  double simTime = Simulator::Now().GetSeconds();
+  for (const auto& statsPair : monitor->GetFlowStats())
+  {
+      auto stats = statsPair.second;
+      double throughputKbps = (stats.rxBytes * 8.0) / simTime / 1000.0;
+      double avgDelayMs = stats.delaySum.GetSeconds() / stats.rxPackets * 1000.0;
+      NS_LOG_UNCOND("Flow " << statsPair.first 
+                   << ": throughput=" << throughputKbps << " kbps, "
+                   << "latency=" << avgDelayMs << " ms");
+  }
   Simulator::Destroy();
 
   return 0;


### PR DESCRIPTION
## Summary
- add FlowMonitor header and helper to wifi-lte traffic example
- report per-flow throughput and latency after the simulation

## Testing
- `./ns3 run scratch/wifi-lte-traffic` *(fails: build interrupted while compiling)*

------
https://chatgpt.com/codex/tasks/task_e_68adb215c7588322a55a63d3afe2875b