### PR TITLE
Add FlowMonitor and LTE video traffic example

### DIFF
--- a/scratch/.gitignore
+++ b/scratch/.gitignore
@@ -10,3 +10,4 @@
 !CMakeLists.txt
 !wifi6-vs-wifi7.cc
 !wifi-lte-traffic.cc
+!lte-video-traffic.cc

--- a/scratch/lte-video-traffic.cc
+++ b/scratch/lte-video-traffic.cc
@@ -1,0 +1,90 @@
+#include "ns3/core-module.h"
+#include "ns3/network-module.h"
+#include "ns3/internet-module.h"
+#include "ns3/lte-module.h"
+#include "ns3/mobility-module.h"
+#include "ns3/point-to-point-module.h"
+#include "ns3/applications-module.h"
+
+using namespace ns3;
+
+NS_LOG_COMPONENT_DEFINE("LteVideoTrafficExample");
+
+int
+main(int argc, char* argv[])
+{
+    Time::SetResolution(Time::NS);
+    CommandLine cmd(__FILE__);
+    cmd.Parse(argc, argv);
+
+    Ptr<LteHelper> lteHelper = CreateObject<LteHelper>();
+    Ptr<PointToPointEpcHelper> epcHelper = CreateObject<PointToPointEpcHelper>();
+    lteHelper->SetEpcHelper(epcHelper);
+
+    Ptr<Node> pgw = epcHelper->GetPgwNode();
+
+    NodeContainer remoteHostContainer;
+    remoteHostContainer.Create(1);
+    Ptr<Node> remoteHost = remoteHostContainer.Get(0);
+    InternetStackHelper internet;
+    internet.Install(remoteHostContainer);
+
+    PointToPointHelper p2ph;
+    p2ph.SetDeviceAttribute("DataRate", DataRateValue(DataRate("1Gb/s")));
+    p2ph.SetChannelAttribute("Delay", TimeValue(MilliSeconds(10)));
+    NetDeviceContainer internetDevices = p2ph.Install(pgw, remoteHost);
+    Ipv4AddressHelper ipv4h;
+    ipv4h.SetBase("1.0.0.0", "255.0.0.0");
+    Ipv4InterfaceContainer internetIpIfaces = ipv4h.Assign(internetDevices);
+    Ipv4StaticRoutingHelper ipv4RoutingHelper;
+    Ptr<Ipv4StaticRouting> remoteHostStaticRouting =
+        ipv4RoutingHelper.GetStaticRouting(remoteHost->GetObject<Ipv4>());
+    remoteHostStaticRouting->AddNetworkRouteTo(Ipv4Address("7.0.0.0"),
+                                               Ipv4Mask("255.0.0.0"), 1);
+
+    NodeContainer ueNodes;
+    NodeContainer enbNodes;
+    ueNodes.Create(1);
+    enbNodes.Create(1);
+
+    MobilityHelper mobility;
+    mobility.SetMobilityModel("ns3::ConstantPositionMobilityModel");
+    mobility.Install(ueNodes);
+    mobility.Install(enbNodes);
+
+    NetDeviceContainer enbDevs = lteHelper->InstallEnbDevice(enbNodes);
+    NetDeviceContainer ueDevs = lteHelper->InstallUeDevice(ueNodes);
+
+    internet.Install(ueNodes);
+    Ipv4InterfaceContainer ueIpIface = epcHelper->AssignUeIpv4Address(NetDeviceContainer(ueDevs));
+    Ptr<Ipv4StaticRouting> ueStaticRouting =
+        ipv4RoutingHelper.GetStaticRouting(ueNodes.Get(0)->GetObject<Ipv4>());
+    ueStaticRouting->SetDefaultRoute(epcHelper->GetUeDefaultGatewayAddress(), 1);
+
+    lteHelper->Attach(ueDevs.Get(0), enbDevs.Get(0));
+
+    uint16_t dlPort = 1234;
+    ApplicationContainer clientApps;
+    ApplicationContainer serverApps;
+
+    PacketSinkHelper sink("ns3::UdpSocketFactory",
+                           InetSocketAddress(Ipv4Address::GetAny(), dlPort));
+    serverApps.Add(sink.Install(ueNodes.Get(0)));
+
+    OnOffHelper onoff("ns3::UdpSocketFactory",
+                      InetSocketAddress(ueIpIface.GetAddress(0), dlPort));
+    onoff.SetAttribute("DataRate", DataRateValue(DataRate("2Mb/s")));
+    onoff.SetAttribute("PacketSize", UintegerValue(1200));
+    clientApps.Add(onoff.Install(remoteHost));
+
+    serverApps.Start(Seconds(0.1));
+    clientApps.Start(Seconds(0.1));
+    serverApps.Stop(Seconds(10.0));
+    clientApps.Stop(Seconds(10.0));
+
+    Simulator::Stop(Seconds(10.0));
+    Simulator::Run();
+    Simulator::Destroy();
+    return 0;
+}
+

--- a/scratch/wifi-lte-traffic.cc
+++ b/scratch/wifi-lte-traffic.cc
@@ -7,6 +7,7 @@
 #include "ns3/udp-client-server-helper.h"
 #include "ns3/packet-sink-helper.h"
 #include "ns3/socket.h"
+#include "ns3/flow-monitor-module.h"
 
 using namespace ns3;
 
@@ -146,8 +147,22 @@ main(int argc, char *argv[])
   voiceApp2->SetStartTime(Seconds(1.0));
   voiceApp2->SetStopTime(Seconds(10.0));
 
+  FlowMonitorHelper flowmonHelper;
+  Ptr<FlowMonitor> monitor = flowmonHelper.InstallAll();
+
   Simulator::Stop(Seconds(10.0));
   Simulator::Run();
+  monitor->CheckForLostPackets();
+  double simTime = Simulator::Now().GetSeconds();
+  for (const auto& statsPair : monitor->GetFlowStats())
+  {
+      auto stats = statsPair.second;
+      double throughputKbps = (stats.rxBytes * 8.0) / simTime / 1000.0;
+      double avgDelayMs = stats.delaySum.GetSeconds() / stats.rxPackets * 1000.0;
+      NS_LOG_UNCOND("Flow " << statsPair.first 
+                   << ": throughput=" << throughputKbps << " kbps, "
+                   << "latency=" << avgDelayMs << " ms");
+  }
   Simulator::Destroy();
 
   return 0;


### PR DESCRIPTION
## Summary
- add FlowMonitor header and helper to wifi-lte traffic example
- report per-flow throughput and latency after the simulation
- add standalone LTE video traffic generation example

## Testing
- `./ns3 run scratch/lte-video-traffic` *(fails: build interrupted by user)*


------
https://chatgpt.com/codex/tasks/task_e_68adb215c7588322a55a63d3afe2875b